### PR TITLE
[add] 新規アイデアグループを作成できるように実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -16,6 +16,8 @@ class GroupsController < ApplicationController
 
   def create
     @group = @brainstorm.groups.build(group_params)
+    # 最後のpositionの次の番号を設定
+    @group.position = @brainstorm.groups.maximum(:position).to_i + 1
     
     if @group.save
       redirect_to brainstorm_path(@brainstorm), notice: "グループを作成しました"

--- a/app/views/brainstorms/show.html.erb
+++ b/app/views/brainstorms/show.html.erb
@@ -64,6 +64,29 @@
 
     <% if @brainstorm.ideas.where.not(id: nil).any? %>
       <% if @brainstorm.groups.any? %>
+        <!-- 新規グループ作成ボタン -->
+        <div class="mb-4">
+          <button onclick="document.getElementById('new-group-form').classList.toggle('hidden')" class="px-4 py-2 bg-green-100 text-green-700 rounded hover:bg-green-200 transition">
+            + 新しいグループを作成
+          </button>
+        </div>
+
+        <!-- 新規グループ作成フォーム（デフォルトは非表示） -->
+        <div id="new-group-form" class="hidden mb-6 bg-gray-50 rounded-lg p-4">
+          <%= form_with(model: [@brainstorm, @brainstorm.groups.build], local: true) do |f| %>
+            <div class="mb-4">
+              <%= f.label :name, "グループ名", class: "block text-gray-700 font-semibold mb-2" %>
+              <%= f.text_field :name, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "例：その他のアイデア", maxlength: 50 %>
+            </div>
+            <div class="flex justify-end space-x-2">
+              <button type="button" onclick="document.getElementById('new-group-form').classList.add('hidden')" class="px-4 py-2 text-gray-600 hover:text-gray-800">
+                キャンセル
+              </button>
+              <%= f.submit "作成", class: "px-6 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition cursor-pointer" %>
+            </div>
+          <% end %>
+        </div>
+
         <!-- グループ表示 -->
         <div class="space-y-6">
           <% @brainstorm.groups.order(:position).each do |group| %>
@@ -108,13 +131,13 @@
                         <!-- グループ移動セレクトボックス -->
                         <%= form_with url: brainstorm_update_group_idea_path(@brainstorm, idea), method: :patch, local: true, class: "inline-block" do |f| %>
                           <%= f.select :group_id, 
-                              options_for_select(
-                                [["グループなし", ""]] + @brainstorm.groups.map { |g| [g.name, g.id] },
-                                group.id
-                              ),
-                              {},
-                              class: "text-sm border rounded px-2 py-1",
-                              onchange: "this.form.submit();" %>
+                            options_for_select(
+                              [["グループなし", ""]] + @brainstorm.groups.where.not(name: [nil, ""]).map { |g| [g.name, g.id] },
+                              group.id
+                            ),
+                            {},
+                            class: "text-sm border rounded px-2 py-1",
+                            onchange: "this.form.submit();" %>
                         <% end %>
                         
                         <%= link_to "編集", edit_brainstorm_idea_path(@brainstorm, idea), class: "text-indigo-600 hover:text-indigo-800 text-sm" %>
@@ -149,12 +172,12 @@
                         
                         <%= form_with url: brainstorm_update_group_idea_path(@brainstorm, idea), method: :patch, local: true, class: "inline-block" do |f| %>
                           <%= f.select :group_id, 
-                              options_for_select(
-                                [["グループなし", ""]] + @brainstorm.groups.map { |g| [g.name, g.id] }
-                              ),
-                              {},
-                              class: "text-sm border rounded px-2 py-1",
-                              onchange: "this.form.submit();" %>
+                            options_for_select(
+                              [["グループなし", ""]] + @brainstorm.groups.where.not(name: nil).where.not(name: "").order(:position).map { |g| [g.name, g.id] }
+                            ),
+                            {},
+                            class: "text-sm border rounded px-2 py-1",
+                            onchange: "this.form.submit();" %>
                         <% end %>
                         
                         <%= link_to "編集", edit_brainstorm_idea_path(@brainstorm, idea), class: "text-indigo-600 hover:text-indigo-800 text-sm" %>


### PR DESCRIPTION
## 概要
新規アイデアグループを作成できるように実装

## 対応Issue
- https://github.com/taiks-623/think_storm/issues/28


## 関連Issue
- なし


## 特筆事項
- なし