### PR TITLE
[fix] エラーの出る部分は一旦実装から外す

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,8 +28,8 @@
 
       <div class="text-center space-y-2">
         <%= link_to "新規登録", new_registration_path(resource_name), class: "text-indigo-600 hover:text-indigo-800" %>
-        <span class="text-gray-400 mx-2">|</span>
-        <%= link_to "パスワードを忘れた方", new_password_path(resource_name), class: "text-indigo-600 hover:text-indigo-800" %>
+        <%# <span class="text-gray-400 mx-2">|</span>%>
+        <%# <%= link_to "パスワードを忘れた方", new_password_path(resource_name), class: "text-indigo-600 hover:text-indigo-800" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
「パスワードを忘れた方」の部分は一旦コメントアウトして、飛べないようにする。
本リリースの時にコメントアウト外してちゃんと機能するように実装する。

## 対応Issue
- https://github.com/taiks-623/think_storm/issues/62


## 関連Issue
- 


## 特筆事項
