### PR TITLE
[fix] 表示名をdisplay_nameに統一・オンラインメンバー表示の再接続問題を修正

### DIFF
--- a/app/channels/brainstorm_channel.rb
+++ b/app/channels/brainstorm_channel.rb
@@ -8,7 +8,7 @@ class BrainstormChannel < ApplicationCable::Channel
       online_key = "brainstorm_#{params[:brainstorm_id]}_online"
       online_members = (Rails.cache.read(online_key) || [])
       unless online_members.any? { |m| m[:id] == current_user.id }
-        online_members << { id: current_user.id, email: current_user.email }
+        online_members << { id: current_user.id, name: current_user.display_name }
         Rails.cache.write(online_key, online_members, expires_in: 1.hour)
       end
 
@@ -16,7 +16,7 @@ class BrainstormChannel < ApplicationCable::Channel
         brainstorm,
         event: "member_connected",
         user_id: current_user.id,
-        email: current_user.email,
+        name: current_user.display_name,
         online_members: online_members
       )
     else
@@ -37,7 +37,7 @@ class BrainstormChannel < ApplicationCable::Channel
       brainstorm,
       event: "member_disconnected",
       user_id: current_user.id,
-      email: current_user.email,
+      name: current_user.display_name,
       online_members: online_members
     )
 

--- a/app/controllers/brainstorms_controller.rb
+++ b/app/controllers/brainstorms_controller.rb
@@ -102,6 +102,12 @@ class BrainstormsController < ApplicationController
     redirect_to invite_brainstorm_path(@brainstorm), notice: "#{role == 'editor' ? '編集者' : '閲覧者'}用の招待リンクを生成しました"
   end
 
+  def online_members
+    online_key = "brainstorm_#{@brainstorm.id}_online"
+    members = Rails.cache.read(online_key) || []
+    render json: { online_members: members }
+  end
+
   private
 
   def set_brainstorm

--- a/app/javascript/channels/brainstorm_channel.js
+++ b/app/javascript/channels/brainstorm_channel.js
@@ -11,6 +11,9 @@ function subscribeToBrainstorm(brainstormId) {
     {
       connected() {
         console.log(`Connected to BrainstormChannel (brainstorm: ${brainstormId})`)
+        fetch(`/brainstorms/${brainstormId}/online_members`)
+          .then(res => res.json())
+          .then(data => handleMemberPresence(data))
       },
 
       disconnected() {
@@ -88,7 +91,7 @@ function handleMemberPresence(data) {
     badge.dataset.userId = member.id
     badge.innerHTML = `
       <span class="w-2 h-2 bg-green-500 rounded-full inline-block"></span>
-      ${member.email}
+      ${member.name}
     `
     container.appendChild(badge)
   })
@@ -97,8 +100,23 @@ function handleMemberPresence(data) {
 document.addEventListener('turbo:load', () => {
   const brainstormEl = document.querySelector('[data-brainstorm-id]')
   if (brainstormEl) {
-    subscribeToBrainstorm(brainstormEl.dataset.brainstormId)
+    const brainstormId = brainstormEl.dataset.brainstormId
+
+    // 既存サブスクリプションを解除して再接続
+    if (brainstormChannelSubscriptions[brainstormId]) {
+      brainstormChannelSubscriptions[brainstormId].unsubscribe()
+      delete brainstormChannelSubscriptions[brainstormId]
+    }
+
+    subscribeToBrainstorm(brainstormId)
   }
+})
+
+document.addEventListener('turbo:before-cache', () => {
+  Object.keys(brainstormChannelSubscriptions).forEach(id => {
+    brainstormChannelSubscriptions[id].unsubscribe()
+    delete brainstormChannelSubscriptions[id]
+  })
 })
 
 export { subscribeToBrainstorm }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,8 @@ class User < ApplicationRecord
     user.save if user.confirmed_at_changed?
     user
   end
+
+  def display_name
+    name.presence || email
+  end
 end

--- a/app/views/brainstorms/show.html.erb
+++ b/app/views/brainstorms/show.html.erb
@@ -17,13 +17,13 @@
           <span class="text-sm text-gray-500">メンバー：</span>
           <%# オーナー %>
           <span class="inline-flex items-center gap-1 px-2 py-1 bg-indigo-100 text-indigo-700 rounded-full text-xs">
-            <%= @brainstorm.user.email %>
+            <%= @brainstorm.user.display_name %>
             <span class="bg-indigo-600 text-white px-1 rounded text-xs">オーナー</span>
           </span>
           <%# 招待メンバー %>
           <% @brainstorm.brainstorm_members.includes(:user).each do |member| %>
             <span class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs">
-              <%= member.user.email %>
+              <%= member.user.display_name %>
               <span class="<%= member.role == 'editor' ? 'bg-green-500' : 'bg-gray-400' %> text-white px-1 rounded text-xs">
                 <%= member.role == 'editor' ? '編集者' : '閲覧者' %>
               </span>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="flex justify-between items-start bg-gray-50 rounded p-2" id="comment-<%= comment.id %>">
   <div>
-    <span class="text-xs font-medium text-gray-700"><%= comment.user.email %></span>
+    <span class="text-xs font-medium text-gray-700"><%= comment.user.display_name %></span>
     <p class="text-sm text-gray-600 mt-0.5"><%= comment.content %></p>
     <span class="text-xs text-gray-400"><%= comment.created_at.strftime("%m/%d %H:%M") %></span>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   # ブレストのCRUD
   resources :brainstorms do
     get 'export_markdown', on: :member
+    get :online_members, on: :member
     resources :ideas, only: [:create, :edit, :update, :destroy] do
       post 'generate', on: :collection
       resources :tags, only: [:create, :destroy]


### PR DESCRIPTION
## 概要
表示名をdisplay_nameに統一・オンラインメンバー表示の再接続問題を修正

## 対応Issue
- https://github.com/taiks-623/think_storm/issues/166


## 関連Issue
- 


## 特筆事項
